### PR TITLE
Fix(actions): Correct artifact handling in PyPI release workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact-${{ matrix.os }}-${{ matrix.cibw_arch }}-wheel
+          name: artifact-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   make_sdist:
@@ -45,6 +45,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: sdist-artifact
         path: dist/*.tar.gz
 
   upload_all:
@@ -54,8 +55,13 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: artifact
-        path: dist
+        pattern: artifact-*
+        path: dist/
+        merge-multiple: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: sdist-artifact
+        path: dist/
 
     - uses: pypa/gh-action-pypi-publish@v1.5.0
       with:


### PR DESCRIPTION
The GitHub Actions workflow for publishing releases to PyPI was failing due to issues with artifact naming and retrieval.

This commit addresses the following:
- Corrected artifact naming in the `build_wheels` job to be OS-specific (e.g., `artifact-ubuntu-22.04`) and removed undefined matrix variables from the name.
- Assigned a unique and explicit name (`sdist-artifact`) to the sdist artifact produced by the `make_sdist` job.
- Modified the `upload_all` job to:
  - Download wheel artifacts using a pattern (`artifact-*`) and merge them into the `dist/` directory.
  - Download the specifically named `sdist-artifact` into the `dist/` directory.

These changes ensure that all wheel and sdist files are correctly gathered into the `dist/` directory before the `pypa/gh-action-pypi-publish` step, allowing the release process to proceed as intended.