### PR TITLE
Fix(actions): Refine workflow triggers for clarity and reliability

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,11 @@
 name: Build
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
 
 jobs:
   build_wheels:


### PR DESCRIPTION
Updates the GitHub Actions workflow `on:` trigger to be more explicit.

The workflow will now trigger on:
- Pushes to the `main` branch.
- When a release is `published`.

This change aims to ensure the workflow reliably triggers for release publishing events, which is necessary for the PyPI upload job. The `upload_all` job itself retains its condition
`if: github.event_name == 'release' && github.event.action == 'published'` as an additional safeguard.